### PR TITLE
Fix: Static site generation and S3 deployment for legal-disclosure page

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,8 +39,12 @@ jobs:
 
     - name: Deploy to S3
       run: |
-        aws s3 sync dist/public/ s3://www.tomohiko.io --delete --cache-control max-age=31536000,public
+        aws s3 sync .output/public/ s3://www.tomohiko.io --delete --cache-control max-age=31536000,public
+        # Override cache control for HTML files to enable immediate updates
         aws s3 cp s3://www.tomohiko.io/index.html s3://www.tomohiko.io/index.html --metadata-directive REPLACE --cache-control max-age=0,no-cache,no-store,must-revalidate --content-type text/html
+        aws s3 cp s3://www.tomohiko.io/legal-disclosure/index.html s3://www.tomohiko.io/legal-disclosure/index.html --metadata-directive REPLACE --cache-control max-age=0,no-cache,no-store,must-revalidate --content-type text/html
+        aws s3 cp s3://www.tomohiko.io/404.html s3://www.tomohiko.io/404.html --metadata-directive REPLACE --cache-control max-age=0,no-cache,no-store,must-revalidate --content-type text/html
+        aws s3 cp s3://www.tomohiko.io/200.html s3://www.tomohiko.io/200.html --metadata-directive REPLACE --cache-control max-age=0,no-cache,no-store,must-revalidate --content-type text/html
 
     - name: Get CloudFront Distribution ID
       id: get-distribution-id

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,8 @@ Auto-generated from all feature plans. Last updated: 2025-09-27
 
 ## Active Technologies
 - JavaScript/TypeScript (Nuxt.js 3) + Nuxt.js 3, TailwindCSS v3, Vue 3 (001-1-abc-123)
+- TypeScript with Nuxt.js 3.17.4, Vue.js 3.5.15 + Nuxt.js 3, Vue Router 4.5.1, TailwindCSS 6.14.0 (002-https-tomohiko-io)
+- Static file-based content (data/legal-disclosure), deployed via static site generation (002-https-tomohiko-io)
 
 ## Project Structure
 ```
@@ -19,6 +21,7 @@ npm test [ONLY COMMANDS FOR ACTIVE TECHNOLOGIES][ONLY COMMANDS FOR ACTIVE TECHNO
 JavaScript/TypeScript (Nuxt.js 3): Follow standard conventions
 
 ## Recent Changes
+- 002-https-tomohiko-io: Added TypeScript with Nuxt.js 3.17.4, Vue.js 3.5.15 + Nuxt.js 3, Vue Router 4.5.1, TailwindCSS 6.14.0
 - 001-1-abc-123: Added JavaScript/TypeScript (Nuxt.js 3) + Nuxt.js 3, TailwindCSS v3, Vue 3
 
 <!-- MANUAL ADDITIONS START -->

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -3,13 +3,10 @@ export default defineNuxtConfig({
   compatibilityDate: '2025-06-02',
   ssr: true,
   nitro: {
+    preset: 'static',
     prerender: {
       routes: ['/', '/legal-disclosure'],
       crawlLinks: true
-    },
-    output: {
-      dir: 'dist',
-      publicDir: 'dist/public'
     }
   },
   app: {


### PR DESCRIPTION
## 問題
https://tomohiko.io/legal-disclosure にアクセスすると AccessDenied エラーが発生していました。

## 原因
1. `nuxt.config.ts`の設定が不適切で、HTMLファイルが`dist/public/`に生成されていなかった
2. GitHub Actionsが存在しない`dist/public/`ディレクトリをS3に同期しようとしていた

## 修正内容
- **nuxt.config.ts**: `nitro.preset: 'static'`を追加し、不要な`output`設定を削除
- **deploy.yml**: 
  - S3同期ディレクトリを`.output/public/`に変更
  - `legal-disclosure/index.html`を含むすべてのHTMLファイルのキャッシュ制御を適切に設定

## 確認方法
マージ後、https://tomohiko.io/legal-disclosure にアクセスして、ページが正常に表示されることを確認してください。