### PR TITLE
fix: Remove GitHub Actions deployment permissions from CDK stack

### DIFF
--- a/infra/lib/infra-stack.ts
+++ b/infra/lib/infra-stack.ts
@@ -169,7 +169,7 @@ export class InfraStack extends cdk.Stack {
       resources: [`arn:aws:cloudfront::${this.account}:distribution/${distribution.distributionId}`],
     }));
 
-    // Add permissions for CloudFormation operations (to get stack outputs and deploy)
+    // Add permissions for CloudFormation read operations (to get stack outputs)
     githubActionsRole.addToPolicy(new iam.PolicyStatement({
       effect: iam.Effect.ALLOW,
       actions: [
@@ -177,43 +177,8 @@ export class InfraStack extends cdk.Stack {
         'cloudformation:DescribeStackResources',
         'cloudformation:DescribeStackEvents',
         'cloudformation:GetTemplate',
-        'cloudformation:UpdateStack',
-        'cloudformation:CreateChangeSet',
-        'cloudformation:DescribeChangeSet',
-        'cloudformation:ExecuteChangeSet',
-        'cloudformation:DeleteChangeSet',
-        'cloudformation:GetStackPolicy',
       ],
       resources: [this.stackId],
-    }));
-
-    // Add permissions for SSM parameter access (required for CDK bootstrap verification)
-    githubActionsRole.addToPolicy(new iam.PolicyStatement({
-      effect: iam.Effect.ALLOW,
-      actions: [
-        'ssm:GetParameter',
-        'ssm:GetParameters',
-      ],
-      resources: [
-        `arn:aws:ssm:${this.region}:${this.account}:parameter/cdk-bootstrap/*`,
-      ],
-    }));
-
-    // Add permissions for CloudFront Function deployment
-    githubActionsRole.addToPolicy(new iam.PolicyStatement({
-      effect: iam.Effect.ALLOW,
-      actions: [
-        'cloudfront:CreateFunction',
-        'cloudfront:UpdateFunction',
-        'cloudfront:DeleteFunction',
-        'cloudfront:DescribeFunction',
-        'cloudfront:GetFunction',
-        'cloudfront:ListFunctions',
-        'cloudfront:UpdateDistribution',
-        'cloudfront:GetDistribution',
-        'cloudfront:GetDistributionConfig',
-      ],
-      resources: ['*'], // CloudFront Functions require wildcard resource
     }));
 
     // Output important values


### PR DESCRIPTION
Removed unnecessary GitHub Actions deployment permissions:
- CloudFormation deployment operations (UpdateStack, ChangeSet, etc.)
- SSM parameter access for CDK bootstrap
- CloudFront Function deployment permissions

Only keeping essential permissions:
- S3 operations for static site deployment
- CloudFront cache invalidation
- CloudFormation read operations for stack outputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)